### PR TITLE
Hero/Headshot Component Image Cache Fix

### DIFF
--- a/src/components/HeroSlide.js
+++ b/src/components/HeroSlide.js
@@ -1,11 +1,16 @@
-import React, { useState } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import styles from './HeroSlide.module.scss'
 import Link from 'next/dist/client/link'
 
 const HeroSlide = ({ src, alt, title, url, opacity, callBack }) => {
   const [isVertical, setIsVertical] = useState(false)
 
+  const mainImgRef = useRef(null)
+  const bkgdImgRef = useRef(null)
+
   const imgSrc = src
+  const image920 = imgSrc.replace('_1920.', '_920.')
+
   const overlayOpacityStyle = {
     width: '100%',
     height: '100%',
@@ -24,7 +29,15 @@ const HeroSlide = ({ src, alt, title, url, opacity, callBack }) => {
     }
   }
 
-  const image920 = imgSrc.replace('_1920.', '_920.')
+  useEffect(() => {
+    ;[mainImgRef, bkgdImgRef].forEach((imgRef) => {
+      if (imgRef.current && imgRef.current.complete) {
+        const originalSrc = imgRef.current.src
+        imgRef.current.src = ''
+        imgRef.current.src = originalSrc
+      }
+    })
+  }, [onImageLoad])
 
   return (
     <div
@@ -45,6 +58,7 @@ const HeroSlide = ({ src, alt, title, url, opacity, callBack }) => {
           src={image920}
           alt={alt || ''}
           onLoad={onImageLoad}
+          ref={mainImgRef}
         />
       </picture>
 
@@ -57,6 +71,7 @@ const HeroSlide = ({ src, alt, title, url, opacity, callBack }) => {
             src={image920}
             alt={alt || ''}
             onLoad={onImageLoad}
+            ref={bkgdImgRef}
           />
         </picture>
       )}

--- a/src/components/HeroSlide.js
+++ b/src/components/HeroSlide.js
@@ -21,6 +21,9 @@ const HeroSlide = ({ src, alt, title, url, opacity, callBack }) => {
   }
 
   const onImageLoad = (e) => {
+    const { naturalWidth, naturalHeight } = e.target
+    setIsVertical(naturalWidth < naturalHeight)
+
     if (callBack) {
       callBack()
     }

--- a/src/components/HeroSlide.js
+++ b/src/components/HeroSlide.js
@@ -21,9 +21,6 @@ const HeroSlide = ({ src, alt, title, url, opacity, callBack }) => {
   }
 
   const onImageLoad = (e) => {
-    const { naturalWidth, naturalHeight } = e.target
-    setIsVertical(naturalWidth < naturalHeight)
-
     if (callBack) {
       callBack()
     }
@@ -32,9 +29,8 @@ const HeroSlide = ({ src, alt, title, url, opacity, callBack }) => {
   useEffect(() => {
     ;[mainImgRef, bkgdImgRef].forEach((imgRef) => {
       if (imgRef.current && imgRef.current.complete) {
-        const originalSrc = imgRef.current.src
-        imgRef.current.src = ''
-        imgRef.current.src = originalSrc
+        const { naturalWidth, naturalHeight } = imgRef.current
+        setIsVertical(naturalWidth < naturalHeight)
       }
     })
   }, [onImageLoad])


### PR DESCRIPTION
JIRA Ticket
[NJP-2346 Hero/Headshot Component Update](https://tbnextjs.atlassian.net/browse/NJP-2346)

Describe Changes in this Pull Request
The HeroSlide component was updated to have a useRefs for the images and a useEffect that reloads each image on load if it was already cached on the server. This should fix any images that were previously loaded to cover the parent to resize as vertical. 

Testing Instructions
Go to [this PR](https://bitbucket.org/tollbrothers/com.tollbrothers.www/pull-requests/3633) in Bitbucket and follow the testing instructions.

Screen Shot(s)/Video(s) of Working Changes
When you are running everything locally according to the PR linked above, http://localhost:3000/luxury-homes-for-sale/Colorado/The-Ridge-at-Ward-Station/Quick-Move-In/269543 should look like this:
![Screenshot 2024-07-12 at 2 18 46 PM](https://github.com/user-attachments/assets/7b3374b1-46f0-4b55-9cab-f8ff0170abba)

### Tasks:

1. [ ] Changes Meet JIRA Tickets Requirements
2. [ ] Commit message with `fix` or `feat` to trigger new release
3. [ ] Tested changes on Mobile, Tablet and Desktop screen sizes
4. [ ] Tested changes on Chrome, FireFox and Safari
5. [ ] Demoed to Design Team (For new features only)
6. [ ] Notified Digital Marketing Team if changes will impact A/B Tests
7. [ ] Checked Tracking/Analytics (Notified Digital Marketing Team if changes impact tracking)
