### PR TITLE
NJP-2649 feat: Make Matterports auto play and quick start

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -245,7 +245,7 @@ const getModelSearchParams = () => {
 
 const getWalkthroughURL = (walkthrough) => {
   let src = ''
-  console.log('wt')
+
   if (walkthrough.type === 'walkthrough::matterport') {
     src =
       'https://my.matterport.com/show/?m=' +

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -245,17 +245,12 @@ const getModelSearchParams = () => {
 
 const getWalkthroughURL = (walkthrough) => {
   let src = ''
+  console.log('wt')
   if (walkthrough.type === 'walkthrough::matterport') {
-    let extraParams = '&nt=1'
-    if (getMediaMatch(992)) {
-      extraParams = '&play=1'
-    }
-
     src =
       'https://my.matterport.com/show/?m=' +
       walkthrough.link +
-      '&ts=2&lp=1&hl=1&qs=1&search=0' +
-      extraParams
+      '&ts=2&lp=1&hl=1&qs=1&play=1&nt=0&search=0'
   } else {
     src = walkthrough.link
     if (!walkthrough.link.includes('?')) {


### PR DESCRIPTION
## JIRA Ticket
https://tbnextjs.atlassian.net/browse/NJP-2649

## Describe Changes in this Pull Request
Update Matterports URLs to use play=1 and qs=1

## Testing Instructions

- Open tb.com project in the package.json update dependencies to:  "@tollbrothers/tollbrothers-ui": "../tollbrothers-ui",
- Run npm i
- Run npm run dev
- http://localhost:3000/luxury-homes-for-sale/Arizona/Sterling-Grove#gallery
- Verify that Matterports open in the Fullscreen gallery with &play=1&qs=1 for both desktop and mobile.
- You should see the matterport start right away without the dollhouse zoom and you shouldn't have to hit the play button on mobile

### Tasks:

1. [x] Changes Meet JIRA Tickets Requirements
2. x ] Commit message with `fix` or `feat` to trigger new release
3. [x] Tested changes on Mobile, Tablet and Desktop screen sizes
4. [x] Tested changes on Chrome, FireFox and Safari
5. [] Demoed to Design Team (For new features only)
6. [] Notified Digital Marketing Team if changes will impact A/B Tests
7. [] Checked Tracking/Analytics (Notified Digital Marketing Team if changes impact tracking)
