### PR TITLE
fix: NJP-2675 update to slider and horizontalslider for walkthrought …

### DIFF
--- a/src/components/HorizontalScroller.js
+++ b/src/components/HorizontalScroller.js
@@ -6,7 +6,7 @@ export const HorizontalScroller = ({
   showArrows,
   classes = {},
   newIndex,
-  closeScrollTo,
+  indexToScrollOnClose,
   getCurrentIndex = () => {}
 }) => {
   const [isNextDisabled, setIsNextDisabled] = useState(false)
@@ -55,8 +55,10 @@ export const HorizontalScroller = ({
   }, [newIndex])
 
   useEffect(() => {
-    scrollToImage(closeScrollTo)
-  }, [closeScrollTo])
+    if (indexToScrollOnClose >= 0) {
+      scrollToImage(indexToScrollOnClose)
+    }
+  }, [indexToScrollOnClose])
 
   const handlePrev = () => {
     const gallery = galleryRef.current
@@ -109,9 +111,7 @@ export const HorizontalScroller = ({
     window.addEventListener('resize', handleResize)
 
     handleResize()
-
     setTimeout(() => setInitialized(true), 500)
-
     return () => {
       window.removeEventListener('resize', handleResize)
     }

--- a/src/components/HorizontalScroller.js
+++ b/src/components/HorizontalScroller.js
@@ -6,6 +6,7 @@ export const HorizontalScroller = ({
   showArrows,
   classes = {},
   newIndex,
+  closeScrollTo,
   getCurrentIndex = () => {}
 }) => {
   const [isNextDisabled, setIsNextDisabled] = useState(false)
@@ -52,6 +53,10 @@ export const HorizontalScroller = ({
   useEffect(() => {
     scrollToImage(newIndex)
   }, [newIndex])
+
+  useEffect(() => {
+    scrollToImage(closeScrollTo)
+  }, [closeScrollTo])
 
   const handlePrev = () => {
     const gallery = galleryRef.current

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -70,7 +70,8 @@ const Slider = ({
             onClick={() => {
               onPrevious({
                 mediaList,
-                slideIndex: sliderRef?.current?.blazeSlider?.stateIndex
+                slideIndex: sliderRef?.current?.blazeSlider?.stateIndex,
+                direction: 'prev'
               })
             }}
             className={`blaze-prev ${styles.button}`}
@@ -82,7 +83,8 @@ const Slider = ({
             onClick={() =>
               onNext({
                 mediaList,
-                slideIndex: sliderRef?.current?.blazeSlider?.stateIndex
+                slideIndex: sliderRef?.current?.blazeSlider?.stateIndex,
+                direction: 'next'
               })
             }
             className={`blaze-next ${styles.button}`}

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -70,8 +70,7 @@ const Slider = ({
             onClick={() => {
               onPrevious({
                 mediaList,
-                slideIndex: sliderRef?.current?.blazeSlider?.stateIndex,
-                direction: 'prev'
+                slideIndex: sliderRef?.current?.blazeSlider?.stateIndex
               })
             }}
             className={`blaze-prev ${styles.button}`}
@@ -83,8 +82,7 @@ const Slider = ({
             onClick={() =>
               onNext({
                 mediaList,
-                slideIndex: sliderRef?.current?.blazeSlider?.stateIndex,
-                direction: 'next'
+                slideIndex: sliderRef?.current?.blazeSlider?.stateIndex
               })
             }
             className={`blaze-next ${styles.button}`}


### PR DESCRIPTION
…card matterport launch schedule tour

NJP-2675
[Please add a link to the JIRA ticket](https://tbnextjs.atlassian.net/jira/software/projects/NJP/boards/1?selectedIssue=NJP-2675&text=2675)

## Describe Changes in this Pull Request
Updating horizontal slider component so when a user closes out of a fullscreen gallery, the horizontal slider pushes the thumbnail into view that corresponds to the last viewed fullscreen item.

## Testing Instructions
pull branch from this repo [[charles/fullScreenMatterportFormLaunch](https://github.com/tollbros/tollbrothers-ui/tree/charles/fullScreenMatterportFormLaunch)]
run npm start

pull tb branch [charles/NJP-2675-matterport-onclose-and-link-to]
- point to local ui in package.json - "@tollbrothers/tollbrothers-ui": "file:../tollbrothers-ui",
- run npm i then npm run dev
- http://localhost:3000/luxury-homes-for-sale/Arizona/Sterling-Grove/Arlington-Collection
- go down to gallery and click on one of the walkthroughs under 3D Walkthroughs and verify when you close out of the fullscreen gallery there is an overlay that reads Tour This Home!
- click it and verify it takes you to the model it is showing with the Schedule a tour form opened up.
- now go back to the community page and click on a thumbnail again and this time scroll next and previous and verify the same popup is visible on the thumbnail that corresponds to the last 3d walkthrough viewed when you hit the close button and that if the thumb nail is originally offscreen it is scrolled into view.
- also verify if the last 3d walkthrough viewed is not a matterport, no overlay is visible. 

## Screen Shot(s)/Video(s) of Working Changes
Please add screen shots or screen recordings showing the changes

### Tasks:

1. [ ] Changes Meet JIRA Tickets Requirements
2. [ ] Commit message with `fix` or `feat` to trigger new release
3. [ ] Tested changes on Mobile, Tablet and Desktop screen sizes
4. [ ] Tested changes on Chrome, FireFox and Safari
5. [ ] Demoed to Design Team (For new features only)
6. [ ] Notified Digital Marketing Team if changes will impact A/B Tests
7. [ ] Checked Tracking/Analytics (Notified Digital Marketing Team if changes impact tracking)
