### PR TITLE
Add debug flag and persist slides between navigation.

### DIFF
--- a/src/components/HeroComponent.js
+++ b/src/components/HeroComponent.js
@@ -47,16 +47,25 @@ export function HeroComponent({
   }
 
   const nextImageLoaded = () => {
-    // console.log("Next Image Loaded");
+    if (window.toll.debugHeroComponent) {
+      console.log('Next image loaded')
+    }
     clearTimeout(waitToFade.current)
     waitToFade.current = setTimeout(() => {
-      // console.log("Fading in next image");
+      if (window.toll.debugHeroComponent) {
+        console.log('Fading in next image')
+      }
       setIsFading(true)
       // eslint-disable-next-line no-unused-vars
       const flipSlides = setTimeout(() => {
-        // console.log("Changing slides");
+        if (window.toll.debugHeroComponent) {
+          console.log('Changing slides')
+        }
+
         if (nextSlide) {
-          // console.log("Setting current slide to next slide");
+          if (window.toll.debugHeroComponent) {
+            console.log('Setting current slide to next slide')
+          }
           setCurrentSlide(nextSlide)
           flipSlidesTimeout()
         }
@@ -71,6 +80,10 @@ export function HeroComponent({
 
     window.toll.heroComponentSlides = null
     window.toll.isHeroComponentFlipping = false
+
+    if (window.toll.debugHeroComponent) {
+      console.log('Hero component mounted')
+    }
 
     return () => {
       clearTimeout(flipSlides.current)

--- a/src/components/HeroComponent.js
+++ b/src/components/HeroComponent.js
@@ -69,7 +69,8 @@ export function HeroComponent({
     return () => {
       clearTimeout(flipSlides.current)
       clearTimeout(waitToFade.current)
-      delete window.toll.heroComponentSlides // Cleanup when component unmounts
+      // We want this to persist since SPA
+      // delete window.toll.heroComponentSlides // Cleanup when component unmounts
       delete window.toll.isHeroComponentFlipping // Cleanup when component unmounts
     }
   }, [])

--- a/src/components/HeroComponent.js
+++ b/src/components/HeroComponent.js
@@ -26,7 +26,10 @@ export function HeroComponent({
     clearTimeout(flipSlides.current)
     const slidesArray = window.toll.heroComponentSlides || slidesRef.current
     window.toll.isHeroComponentFlipping = true
-    // console.log('Flipping slides')
+
+    if (window.toll.debugHeroComponent) {
+      console.log('Flipping slides', slidesArray)
+    }
 
     flipSlides.current = setTimeout(() => {
       setIsFading(false)
@@ -36,7 +39,10 @@ export function HeroComponent({
       }
       setCurrentSlideIndex(nextIndex)
       window.toll.isHeroComponentFlipping = false
-      // console.log('Flipping slides done')
+
+      if (window.toll.debugHeroComponent) {
+        console.log('Flipping slides done')
+      }
     }, 1000)
   }
 


### PR DESCRIPTION
This PR does two things:
1. Puts console logs behind debug flag `window.toll.debugHeroComponent`.
2. Removes the delete of the `window.toll.heroComponentSlides` on unmount. This will allow slides to persist between on site navigation `e.g. model page -> home page navigation`. 

```javascript
window.toll.debugHeroComponent = true
```