### PR TITLE
phil/resetHeroSlides

### DIFF
--- a/src/components/HeroComponent.js
+++ b/src/components/HeroComponent.js
@@ -29,9 +29,11 @@ export function HeroComponent({
   const flipSlides = useRef(null)
 
   const resetHeroSlides = () => {
-    arrayRotate(window.toll.heroComponentSlides, true)
-    arrayRotate(window.toll.heroComponentSlides, true)
-    setCurrentSlideIndex((prevIndex) => prevIndex + 1)
+    if (window.toll?.heroComponentSlides) {
+      arrayRotate(window.toll.heroComponentSlides, true)
+      arrayRotate(window.toll.heroComponentSlides, true)
+      setCurrentSlideIndex((prevIndex) => prevIndex + 1)
+    }
   }
 
   const flipSlidesTimeout = () => {

--- a/src/components/HeroComponent.js
+++ b/src/components/HeroComponent.js
@@ -2,6 +2,12 @@ import React, { useState, useEffect, useRef } from 'react'
 import styles from './HeroComponent.module.scss'
 import HeroSlide from './HeroSlide'
 
+function arrayRotate(arr, reverse) {
+  if (reverse) arr.unshift(arr.pop())
+  else arr.push(arr.shift())
+  return arr
+}
+
 export function HeroComponent({
   children,
   slides,
@@ -21,6 +27,12 @@ export function HeroComponent({
 
   const waitToFade = useRef(null)
   const flipSlides = useRef(null)
+
+  const resetHeroSlides = () => {
+    arrayRotate(window.toll.heroComponentSlides, true)
+    arrayRotate(window.toll.heroComponentSlides, true)
+    setCurrentSlideIndex((prevIndex) => prevIndex + 1)
+  }
 
   const flipSlidesTimeout = () => {
     clearTimeout(flipSlides.current)
@@ -80,6 +92,7 @@ export function HeroComponent({
 
     window.toll.heroComponentSlides = null
     window.toll.isHeroComponentFlipping = false
+    window.toll.resetHeroSlides = resetHeroSlides
 
     if (window.toll.debugHeroComponent) {
       console.log('Hero component mounted')


### PR DESCRIPTION
Immediately after loading the homepage run the two following and after the first load the second image should show 'FIRST IMAGE'.

```
window.toll.heroComponentSlides = [
    {
        "image": "https://cdn.tollbrothers.com/sites/comtollbrotherswww/home/heroImages/6-Sterling-Grove-in-Surprise-AZ_1920.jpg",
        "title": "FIRST IMAGE",
        "URL": "/luxury-homes-for-sale/Arizona/Sterling-Grove",
        "mcid": 768
    },
    {
        "image": "https://cdn.tollbrothers.com/sites/comtollbrotherswww/home/heroImages/50-Toll-Brothers-at-Adero-Canyon-in-Fountain-Hills-AZ_1920.jpg",
        "title": "SECOND IMAGE",
        "URL": "/luxury-homes-for-sale/Arizona/Toll-Brothers-at-Adero-Canyon",
        "mcid": 764
    },
    {
        "image": "https://cdn.tollbrothers.com/sites/comtollbrotherswww/home/heroImages/36-Canyon-Point-At-Traverse-Mountain-in-Draper-UT_1920.jpg",
        "title": "THIRD IMAGE",
        "URL": "/luxury-homes-for-sale/Utah/Canyon-Point-at-Traverse-Mountain",
        "mcid": 757
    },
    {
        "image": "https://cdn.tollbrothers.com/sites/comtollbrotherswww/home/heroImages/30-Bartram-Ranch-in-St.-Johns-FL_1920.jpg",
        "title": "FOURTH IMAGE",
        "URL": "/luxury-homes-for-sale/Florida/Bartram-Ranch",
        "cid": 13236
    },
    {
        "image": "https://cdn.tollbrothers.com/sites/comtollbrotherswww/home/heroImages/9-Hillcrest-At-Porter-Ranch-Ridge-Collection-in-Porter-Ranch-CA_1920.jpg",
        "title": "FIFTH IMAGE",
        "URL": "/luxury-homes-for-sale/California/Porter-Ranch",
        "mcid": 683
    },
    {
        "image": "https://cdn.tollbrothers.com/sites/comtollbrotherswww/home/heroImages/47-Hillcrest-At-Porter-Ranch-Ridge-Collection-in-Porter-Ranch-CA_1920.jpg",
        "title": "SIXTH IMAGE",
        "URL": "/luxury-homes-for-sale/California/Porter-Ranch",
        "mcid": 683
    },
]
window.toll.resetHeroSlides()

```