### PR TITLE
NJP-2744 Allow for container width usage instead of window width

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Run `npm run start` in the tollbrothers-ui project
 Run `npm run watch` in the tollbrothers-ui project in another terminal window
 
 # Step 2.
-Run `yalc link @tollbrothers/tollbrothers-ui` in the parent project
+Run `yalc link @tollbrothers/tollbrothers-ui` in the parent project.
 
 # Clean up
 Run `yalc remove @tollbrothers/tollbrothers-ui && npm install` in the parent project 

--- a/src/components/HorizontalScroller.js
+++ b/src/components/HorizontalScroller.js
@@ -6,7 +6,8 @@ export const HorizontalScroller = ({
   showArrows,
   classes = {},
   newIndex,
-  getCurrentIndex = () => {}
+  getCurrentIndex = () => {},
+  useContainerWidth = false
 }) => {
   const [isNextDisabled, setIsNextDisabled] = useState(false)
   const [isPrevDisabled, setIsPrevDisabled] = useState(true)
@@ -96,7 +97,11 @@ export const HorizontalScroller = ({
   // to detect if window is wider than gallery
   useEffect(() => {
     const handleResize = () => {
-      window.innerWidth >= galleryRef.current?.scrollWidth
+      const containerWidth = useContainerWidth
+        ? galleryRef?.current?.clientWidth
+        : window.innerWidth
+
+      containerWidth >= galleryRef.current?.scrollWidth
         ? setShowGalleryNav(false)
         : setShowGalleryNav(true)
     }


### PR DESCRIPTION
## JIRA Ticket
https://tbnextjs.atlassian.net/browse/NJP-2744

## Describe Changes in this Pull Request
Added a prop to HorizontalScroller component to use the container width instead of the window width.

## Testing Instructions
Can be tested with: https://bitbucket.org/tollbrothers/com.tollbrothers.www/pull-requests/5588

Test the container size is being used and test other scrollers that don't have that prop on tb.com (Home Designs, QMI carousel, etc.)

### Tasks:

1. [] Changes Meet JIRA Tickets Requirements
2. [x] Commit message with `fix` or `feat` to trigger new release
3. [x] Tested changes on Mobile, Tablet and Desktop screen sizes
4. [x] Tested changes on Chrome, FireFox and Safari
5. [] Demoed to Design Team (For new features only)
6. [] Notified Digital Marketing Team if changes will impact A/B Tests
7. [] Checked Tracking/Analytics (Notified Digital Marketing Team if changes impact tracking)
