### PR TITLE
Add permissions for id-token in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,3 +23,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
+permissions:
+  id-token: write


### PR DESCRIPTION

Need this for the workflow per https://www.npmjs.com/package/@semantic-release/npm

```
Trusted publishing from GitHub Actions
To leverage trusted publishing and publish with provenance from GitHub Actions, the id-token: write permission is required to be enabled on the job:

permissions:
  id-token: write # to enable use of OIDC for trusted publishing and npm proven
```