### PR TITLE
NJP-3156 - adjusted hscroller to handle variable widths - first pass …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14609,21 +14609,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/semantic-release/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",

--- a/src/components/HorizontalScroller.js
+++ b/src/components/HorizontalScroller.js
@@ -27,17 +27,12 @@ export const HorizontalScroller = ({
       ? setIsNextDisabled(true)
       : setIsNextDisabled(false)
 
-    gallery.scrollLeft === 0
-      ? setIsPrevDisabled(true)
-      : setIsPrevDisabled(false)
+    gallery.scrollLeft === 0 ? setIsPrevDisabled(true) : setIsPrevDisabled(false)
 
     let closestIndex = 0
     let closestDistance = Number.MAX_VALUE
     for (let i = 0; i < gallery.children.length; i++) {
-      const distance = Math.abs(
-        gallery.children[i].getBoundingClientRect().left -
-          gallery.getBoundingClientRect().left
-      )
+      const distance = Math.abs(gallery.children[i].getBoundingClientRect().left - gallery.getBoundingClientRect().left)
       if (distance < closestDistance) {
         closestDistance = distance
         closestIndex = i
@@ -79,13 +74,10 @@ export const HorizontalScroller = ({
       // const imageWidth = galleryRef.current.firstChild.clientWidth
       let totalWidth = 0
       for (let i = 0; i < index; i++) {
-        const computedStyle = window.getComputedStyle(
-          galleryRef.current.children[i]
-        )
+        const computedStyle = window.getComputedStyle(galleryRef.current.children[i])
         const marginLeft = parseFloat(computedStyle.marginLeft.split('px')[0])
         const marginRight = parseFloat(computedStyle.marginRight.split('px')[0])
-        totalWidth +=
-          galleryRef.current.children[i].clientWidth + marginLeft + marginRight
+        totalWidth += galleryRef.current.children[i].clientWidth + marginLeft + marginRight
       }
       galleryRef.current.scrollTo({
         left: totalWidth,
@@ -98,21 +90,16 @@ export const HorizontalScroller = ({
   useEffect(() => {
     const handleResize = () => {
       if (!galleryRef.current) return
-      const containerWidth = useContainerWidth
-        ? galleryRef.current.clientWidth
-        : window.innerWidth
+      const containerWidth = useContainerWidth ? galleryRef.current.clientWidth : window.innerWidth
 
-      containerWidth >= galleryRef.current.scrollWidth
-        ? setShowGalleryNav(false)
-        : setShowGalleryNav(true)
+      containerWidth >= galleryRef.current.scrollWidth ? setShowGalleryNav(false) : setShowGalleryNav(true)
     }
 
     window.addEventListener('resize', handleResize)
 
     handleResize()
 
-    // Re-measure when content size changes (e.g., async-loaded images
-    // resolving their intrinsic dimensions after mount).
+    // fire handleResize on async-loaded images
     let resizeObserver
     if (galleryRef.current && typeof ResizeObserver !== 'undefined') {
       resizeObserver = new ResizeObserver(handleResize)
@@ -135,25 +122,19 @@ export const HorizontalScroller = ({
       {showArrows && showGalleryNav && (
         <div className={`${styles.controls} ${classes.controls ?? ''}`}>
           <button onClick={handlePrev} disabled={isPrevDisabled}>
-            <img
-              src='https://cdn.tollbrothers.com/sites/comtollbrotherswww/svg/arrowexit.svg'
-              alt='Previous Slide'
-            />
+            <img src='https://cdn.tollbrothers.com/sites/comtollbrotherswww/svg/arrowexit.svg' alt='Previous Slide' />
           </button>
           <button onClick={handleNext} disabled={isNextDisabled}>
-            <img
-              src='https://cdn.tollbrothers.com/sites/comtollbrotherswww/svg/arrowexit.svg'
-              alt='Next Slide'
-            />
+            <img src='https://cdn.tollbrothers.com/sites/comtollbrotherswww/svg/arrowexit.svg' alt='Next Slide' />
           </button>
         </div>
       )}
 
       <div className={`${styles.viewPort}`}>
         <div
-          className={`${styles.scrollWrap} ${
-            children.length === 1 ? styles.noMargin : ''
-          } ${classes.scrollWrap ?? ''} scrollWrap`}
+          className={`${styles.scrollWrap} ${children.length === 1 ? styles.noMargin : ''} ${
+            classes.scrollWrap ?? ''
+          } scrollWrap`}
           ref={galleryRef}
           onScroll={handleScroll}
         >
@@ -161,9 +142,7 @@ export const HorizontalScroller = ({
             return (
               child && (
                 <div
-                  className={`${styles.scrollItem} ${
-                    classes.scrollItem ?? ''
-                  } scrollItem`}
+                  className={`${styles.scrollItem} ${classes.scrollItem ?? ''} scrollItem`}
                   ref={slideRef}
                   key={child.key}
                   data-index={index}

--- a/src/components/HorizontalScroller.js
+++ b/src/components/HorizontalScroller.js
@@ -97,11 +97,12 @@ export const HorizontalScroller = ({
   // to detect if window is wider than gallery
   useEffect(() => {
     const handleResize = () => {
+      if (!galleryRef.current) return
       const containerWidth = useContainerWidth
-        ? galleryRef?.current?.clientWidth
+        ? galleryRef.current.clientWidth
         : window.innerWidth
 
-      containerWidth >= galleryRef.current?.scrollWidth
+      containerWidth >= galleryRef.current.scrollWidth
         ? setShowGalleryNav(false)
         : setShowGalleryNav(true)
     }
@@ -110,10 +111,22 @@ export const HorizontalScroller = ({
 
     handleResize()
 
+    // Re-measure when content size changes (e.g., async-loaded images
+    // resolving their intrinsic dimensions after mount).
+    let resizeObserver
+    if (galleryRef.current && typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(handleResize)
+      resizeObserver.observe(galleryRef.current)
+      Array.from(galleryRef.current.children).forEach((child) => {
+        resizeObserver.observe(child)
+      })
+    }
+
     setTimeout(() => setInitialized(true), 500)
 
     return () => {
       window.removeEventListener('resize', handleResize)
+      if (resizeObserver) resizeObserver.disconnect()
     }
   }, [])
 


### PR DESCRIPTION
To test this, pull this branch locally.

in the tb.com project pull this branch from tb.com:

`git checkout claude/NJP-3156` 

`yalc` connect this and then look at this community:

http://localhost:3000/luxury-homes-for-sale/Florida/Summercrest-by-Toll-Brothers#gallery

note the thin image:

<img width="542" height="591" alt="image" src="https://github.com/user-attachments/assets/99c315f6-db2f-482a-94dd-2c76c71bcb02" />


also note the wide image:

<img width="1616" height="591" alt="image" src="https://github.com/user-attachments/assets/a3335a8f-566c-4e9f-9ce7-a4fceffd05bf" />



---

…- used Claude - cost 5 bucks.

## Summary

Re-measure `scrollWidth` when content size changes so the prev/next nav arrows show correctly when child sizes are determined after mount (e.g., images that report `width: auto` until their intrinsic dimensions resolve on load).

Previously, `handleResize` only ran on mount and on `window resize`. With fixed-width children that was fine, but children whose width is driven by async-loaded content measured as 0 at mount, causing `showGalleryNav` to latch to `false` and the nav to never appear.

## Changes

- `HorizontalScroller.js`: attach a `ResizeObserver` to the gallery ref and its immediate children; calls the existing `handleResize` whenever any of them resize. Disconnected on unmount. Guarded with `typeof ResizeObserver !== 'undefined'` for SSR.

No API or visual changes for existing consumers — fixed-width children never resize after mount, so the observer is a no-op for them.

## Test plan

- [ ] Existing scrollers (walkthroughs, elevations, anything with fixed-width tiles) still show/hide arrows correctly.
- [ ] A scroller with `width: auto` tiles driven by `<img>` natural size shows arrows once images load.
- [ ] Resizing the window still toggles arrow visibility.
- [ ] No console errors in SSR.

